### PR TITLE
Skip negative ink payouts in gamecore

### DIFF
--- a/packages/gamecore/src/index.js
+++ b/packages/gamecore/src/index.js
@@ -11,6 +11,7 @@ for await (const m of sub) {
   try {
     const trade = JSON.parse(m.data);
     const ink = Math.floor(trade.pnl_usd * trade.leverage_x);
+    if (ink < 0) continue; // skip negative payouts
     await pg.query(
       'INSERT INTO ink_ledger(trade_id, ink_delta) VALUES ($1, $2)',
       [trade.trade_id, ink]


### PR DESCRIPTION
## Summary
- avoid negative ink payouts

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685a1281b2dc83229c21bed8d750c036