### PR TITLE
Update CORS headers for websocket protocol

### DIFF
--- a/packages/api-gateway/src/main.js
+++ b/packages/api-gateway/src/main.js
@@ -10,7 +10,10 @@ dotenv.config();
 const nats = await connect({ servers: process.env.NATS_URL });
 const pg = new Pool({ connectionString: process.env.DATABASE_URL });
 const app = Fastify();
-app.register(cors, { origin: '*' });
+app.register(cors, {
+  origin: '*', // TODO tighten in prod
+  allowedHeaders: ['sec-websocket-protocol'] // future JWT / wallet-sig
+});
 app.register(ws);
 
 app.post('/trades/open', async (req, reply) => {


### PR DESCRIPTION
## Summary
- update CORS registration in `api-gateway` to allow `sec-websocket-protocol`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685a0b6cb4788322895e1d864e115521