### PR TITLE
Add module type to package files

### DIFF
--- a/packages/api-gateway/package.json
+++ b/packages/api-gateway/package.json
@@ -1,6 +1,7 @@
 {
   "name": "api-gateway",
   "version": "0.0.1",
+  "type": "module",
   "scripts": {
     "dev": "nodemon -x node src/main.js"
   },

--- a/packages/gamecore/package.json
+++ b/packages/gamecore/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gamecore",
   "version": "0.0.1",
+  "type": "module",
   "scripts": {
     "dev": "nodemon -x node src/index.js"
   },


### PR DESCRIPTION
## Summary
- enable ES module syntax for packages

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a178adff08322ba04bcca4fcc2793