### PR TITLE
Add health check endpoints

### DIFF
--- a/packages/api-gateway/src/main.js
+++ b/packages/api-gateway/src/main.js
@@ -16,6 +16,10 @@ app.register(cors, {
 });
 app.register(ws);
 
+app.get('/healthz', async () => {
+  return { ok: true };
+});
+
 app.post('/trades/open', async (req, reply) => {
   try {
     const body = req.body;

--- a/packages/gamecore/src/index.js
+++ b/packages/gamecore/src/index.js
@@ -1,8 +1,14 @@
+import Fastify from 'fastify';
 import { connect as connectNats } from 'nats';
 import { Pool } from 'pg';
 import dotenv from 'dotenv';
 
 dotenv.config();
+const app = Fastify();
+app.get('/healthz', async () => {
+  return { ok: true };
+});
+await app.listen({ port: 3001 });
 const nats = await connectNats({ servers: process.env.NATS_URL });
 const pg = new Pool({ connectionString: process.env.DATABASE_URL });
 


### PR DESCRIPTION
## Summary
- implement simple GET /healthz in API Gateway
- add Fastify server with /healthz in Gamecore

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a179c883c8322aca178a296d40998