### PR TITLE
Resolve engine duplication and improve back pressure

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -110,13 +110,16 @@ class SwipeBar extends StatefulWidget {
 
 class _SwipeBarState extends State<SwipeBar> {
   double _position = 0;
+  String userWallet = '0xabc';
+  String selectedAsset = 'BTC';
+  int leverage = 3;
 
   Future<void> _sendTrade(int dir) async {
     final body = jsonEncode({
-      'user': '0xabc',
-      'asset': 'BTC',
+      'user':   userWallet,
+      'asset':  selectedAsset,
       'dir': dir,
-      'lev': 3,
+      'lev':    leverage,
     });
     await http.post(
       Uri.parse('$_apiBase/trades/open'),

--- a/package.json
+++ b/package.json
@@ -6,21 +6,15 @@
     "packages/*",
     "frontend"
   ],
-  "engines": {
-    "node": ">=20.0.0"
-  },
   "scripts": {
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo dev --parallel",
     "lint": "turbo lint",
     "test": "turbo test",
-    "db:migrate": "psql $DATABASE_URL -f scripts/migrate.sql"
+    "db:migrate": "bash -c 'psql \"${DATABASE_URL?}\" -f scripts/migrate.sql'"
   },
   "devDependencies": {
     "nodemon": "^3.1.1",
     "turbo": "^2.5.4"
   },
-  "engines": {
-    "node": ">=20.0.0"
-    "turbo": "^2"
-  }
+  "engines": { "node": ">=20.0.0" }
 }

--- a/packages/api-gateway/src/main.js
+++ b/packages/api-gateway/src/main.js
@@ -15,11 +15,7 @@ app.register(cors, {
   allowedHeaders: ['sec-websocket-protocol'] // future JWT / wallet-sig
 });
 app.register(ws);
-app.get('/healthz', async (_, reply) => reply.code(200).send({ ok: true }));
-
-app.get('/healthz', async () => {
-  return { ok: true };
-});
+app.get('/healthz', async () => ({ ok: true }));
 
 app.post('/trades/open', async (req, reply) => {
   try {
@@ -70,7 +66,6 @@ app.get('/ws/ink', { websocket: true }, (socket) => {
       cleanup();
     }
   })();
-  socket.on('close', () => sub.unsubscribe());
 });
 
 app.get('/ws/rewards', { websocket: true }, (socket) => {
@@ -78,7 +73,9 @@ app.get('/ws/rewards', { websocket: true }, (socket) => {
   void (async () => {
     try {
       for await (const m of sub) {
-        socket.raw.write(m.data);
+        if (!socket.raw.write(m.data)) {
+          await new Promise(res => socket.raw.once('drain', res));
+        }
       }
     } catch (err) {
       app.log.error(err, 'WS reward relay error');

--- a/packages/gamecore/src/index.js
+++ b/packages/gamecore/src/index.js
@@ -5,22 +5,23 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 const app = Fastify();
-app.get('/healthz', async () => {
-  return { ok: true };
-});
+app.get('/healthz', async () => ({ ok: true }));
 await app.listen({ port: 3001 });
 const nats = await connectNats({ servers: process.env.NATS_URL });
 const pg = new Pool({ connectionString: process.env.DATABASE_URL });
-const app = Fastify();
-app.get('/healthz', async () => ({ ok: true }));
-app.listen({ port: 3001 }, () => console.log('Gamecore 3001'));
 
-const sub = nats.subscribe('trade.closed');
+const js = nats.jetstream();
+const sub = await js.pullSubscribe('trade.closed', { durable: 'gamecore' });
+const pull = () => sub.pull({ batch: 1, expires: 1000 });
+pull();
 for await (const m of sub) {
   try {
     const trade = JSON.parse(m.data);
     const ink = Math.floor(trade.pnl_usd * trade.leverage_x);
-    if (ink < 0) continue; // skip negative payouts
+    if (ink < 0) {
+      m.ack();
+      continue;
+    }
     await pg.query(
       'INSERT INTO ink_ledger(trade_id, ink_delta) VALUES ($1, $2)',
       [trade.trade_id, ink]
@@ -41,8 +42,11 @@ for await (const m of sub) {
       );
     }
     console.log('Ink updated', trade.trade_id, ink);
+    m.ack();
   } catch (err) {
     console.error(err);
+  } finally {
+    pull();
   }
 }
 

--- a/scripts/migrate.sql
+++ b/scripts/migrate.sql
@@ -20,6 +20,8 @@ CREATE TABLE IF NOT EXISTS tiles (
   y INTEGER
 );
 
+ALTER TABLE tiles ADD CONSTRAINT tiles_xy_unique UNIQUE (x, y);
+
 CREATE TABLE IF NOT EXISTS user_streaks (
   user_addr TEXT PRIMARY KEY,
   streak INTEGER NOT NULL CHECK (streak >= 0)


### PR DESCRIPTION
## Summary
- remove duplicate `engines` key and switch to `turbo dev`
- quote DATABASE_URL in migrate script
- use single Fastify server in gamecore and convert consumer to JetStream pull with manual ack
- deduplicate `/healthz` route
- add proper back‑pressure handling on `/ws/rewards`
- drop duplicate WebSocket close handler
- enforce UNIQUE(x,y) for tiles table
- parameterise Flutter trade request

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685a24fc4e9c83228aef4d9fd37e93fd