### PR TITLE
fix ci node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   TURBO_DISABLE_TELEMETRY: '1'
 
 jobs:
-  node:
+  node-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,8 +20,8 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install
-      - run: npx turbo run lint --filter=./packages...
-      - run: pnpm test
+      - run: npx turbo run lint --filter=./packages/*
+      - run: pnpm test:node
 
   flutter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run node tests with coverage and update lint filter

## Testing
- `pnpm install`
- `npx turbo run lint --filter=./packages/*`
- `pnpm test:node`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a572f638483228b0f61aadf7a4edb