### PR TITLE
fix: narrow Jest coverage ignore

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,7 +4,8 @@ module.exports = {
   verbose: true,
   clearMocks: true,
   coveragePathIgnorePatterns: [
-    '/packages/api-gateway/src/'
+    '/packages/api-gateway/src/generated/',
+    '/packages/api-gateway/src/main.js'
   ],
   coverageThreshold: {
     global: { lines: 80 }


### PR DESCRIPTION
## Summary
- tweak coveragePathIgnorePatterns to skip generated code and main.js only

## Testing
- `pnpm install`
- `npx turbo lint`
- `pnpm test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5a0a38f883229a9eebd019cfb37f