### PR TITLE
Add combined test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ pnpm --filter frontend dev
 ## Additional Tips
 
 - **Logging & Monitoring:** Check logs in terminal windows for each service. Use Docker logs for Postgres and NATS.  
-- **Testing:** Run unit and integration tests with `pnpm test` or service-specific commands.
+- **Testing:** Run unit and integration tests with `pnpm test` (Node only). Use `pnpm test:all` to include Flutter tests.
 - **UI tests require the Flutter SDK.** Run `pnpm --filter frontend flutter:test` locally before committing UI changes.
 - **Code Formatting:** Use `pnpm lint` and `pnpm format` to maintain code style consistency.
 - **CI/CD:** Ensure your CI pipeline runs `pnpm install`, `pnpm db:migrate`, and tests before deployment.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "turbo dev --parallel",
     "lint": "turbo lint",
     "test": "turbo test",
+    "test:all": "pnpm test && pnpm --filter frontend flutter:test",
     "test:node": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "coverage": "jest --coverage",
     "db:migrate": "bash -c 'psql \"${DATABASE_URL?}\" -f scripts/migrate.sql'"


### PR DESCRIPTION
## Summary
- add a `test:all` script running Node and Flutter tests
- document usage in README

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm --filter frontend flutter:test` *(fails: `flutter` not found)*
- `pnpm test:all` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5a5471788322a7f961a5299555da